### PR TITLE
Fixing ambiguous option error when two flags are similar to "out".

### DIFF
--- a/pkg/az/action.go
+++ b/pkg/az/action.go
@@ -63,7 +63,7 @@ func (s Step) GetArguments() []string {
 }
 
 func (s Step) GetFlags() builder.Flags {
-	return append(s.Flags, builder.NewFlag("out", "json"))
+	return append(s.Flags, builder.NewFlag("output", "json"))
 }
 
 func (s Step) GetOutputs() []builder.Output {

--- a/pkg/az/action_test.go
+++ b/pkg/az/action_test.go
@@ -38,5 +38,5 @@ func TestStep_GetFlags(t *testing.T) {
 	f := s.GetFlags()
 
 	require.Len(t, f, 1, "Flags should always have at least 1 entry: --out")
-	assert.Equal(t, builder.NewFlag("out", "json"), f[0])
+	assert.Equal(t, builder.NewFlag("output", "json"), f[0])
 }

--- a/pkg/az/action_test.go
+++ b/pkg/az/action_test.go
@@ -37,6 +37,6 @@ func TestStep_GetFlags(t *testing.T) {
 
 	f := s.GetFlags()
 
-	require.Len(t, f, 1, "Flags should always have at least 1 entry: --out")
+	require.Len(t, f, 1, "Flags should always have at least 1 entry: --output")
 	assert.Equal(t, builder.NewFlag("output", "json"), f[0])
 }

--- a/pkg/az/execute_test.go
+++ b/pkg/az/execute_test.go
@@ -24,7 +24,7 @@ func TestMixin_Execute(t *testing.T) {
 		wantCommand string
 	}{
 		{"install", "testdata/install-input.yaml", "",
-			"az login --out json --password password --service-principal --tenant tenant --username client-id"},
+			"az login --output json --password password --service-principal --tenant tenant --username client-id"},
 	}
 
 	defer os.Unsetenv(test.ExpectedCommandEnv)


### PR DESCRIPTION
When using the az mixin with "az iot hub device-identity create" it does not succeed because there are two similar flags "output" and "output-dir". 

Adding in the full "output" flag to the command removes this issue.

Example: 
ERROR: az iot hub device-identity create: error: ambiguous option: --out could match --output, --output-dir