### PR TITLE
Use additionalProperties instead of patternProperties

### DIFF
--- a/pkg/az/schema/schema.json
+++ b/pkg/az/schema/schema.json
@@ -119,13 +119,10 @@
       }
     }
   },
-  "patternProperties": {
-    ".*": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/invokeStep"
-      }
+  "additionalProperties": {
+    "type": "array",
+    "items": {
+      "$ref": "#/definitions/invokeStep"
     }
-  },
-  "additionalProperties": false
+  }
 }


### PR DESCRIPTION
This fixes validation, where patternProperties applies on top of those defined in properties, additionalProperties is applied to those not matched in properties.

This is follow-up to https://github.com/deislabs/porter/pull/677