### PR TITLE
Fix schema command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifndef HAS_PACKR2
 	$(GO) get -u github.com/gobuffalo/packr/v2/packr2
 endif
 
-xbuild-all:
+xbuild-all: generate
 	$(foreach OS, $(SUPPORTED_PLATFORMS), \
 		$(foreach ARCH, $(SUPPORTED_ARCHES), \
 				$(MAKE) $(MAKE_OPTS) CLIENT_PLATFORM=$(OS) CLIENT_ARCH=$(ARCH) MIXIN=$(MIXIN) xbuild; \

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,16 @@ $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT):
 	mkdir -p $(dir $@)
 	GOOS=$(CLIENT_PLATFORM) GOARCH=$(CLIENT_ARCH) $(XBUILD) -o $@ ./cmd/$(MIXIN)
 
-test: test-unit
+test: test-unit test-integration
 	$(BINDIR)/$(MIXIN)$(FILE_EXT) version
 
-test-unit: build
-	$(GO) test ./...
+test-unit:
+	$(GO) test ./pkg/...
+
+test-integration: xbuild
+	# Test against the cross-built client binary that we will publish
+	cp $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT) $(BINDIR)/$(MIXIN)$(FILE_EXT)
+	$(GO) test -tags=integration ./tests/...
 
 publish: bin/porter$(FILE_EXT)
 	# AZURE_STORAGE_CONNECTION_STRING will be used for auth in the following commands

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,12 +32,17 @@ steps:
 - script: |
      make build test-unit
   workingDirectory: '$(modulePath)'
-  displayName: 'Unit Test'
+  displayName: 'Test Unit'
 
 - script: |
     make xbuild-all
   workingDirectory: '$(modulePath)'
   displayName: 'Cross Compile'
+
+- script: |
+    make test-integration
+  workingDirectory: '$(modulePath)'
+  displayName: 'Test Integration'
 
 - script: |
     AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING) make publish

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,7 @@ github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/gorm v1.9.11/go.mod h1:bu/pK8szGZ2puuErfU0RwyeNdsf3e6nCX/noXaVxkfw=
@@ -228,6 +229,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/kisom/goutils v1.1.0/go.mod h1:+UBTfd78habUYWFbNWTJNG+jNG/i/lGURakr4A/yNRw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/tests/schema_integration_test.go
+++ b/tests/schema_integration_test.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Add a test that checked that the schema was packed into the binary
+// properly. Requires a make clean xbuild-all first.
+func TestSchema(t *testing.T) {
+	schemaBackup := "../pkg/az/schema/schema.json.bak"
+	schemaPath := "../pkg/az/schema/schema.json"
+	defer os.Rename(schemaBackup, schemaPath)
+	err := os.Rename(schemaPath, schemaBackup)
+	require.NoError(t, err, "failed to sabotage the schema.json")
+
+	output := &bytes.Buffer{}
+	cmd := exec.Command("az", "schema")
+	cmd.Path =  "../bin/mixins/az/az"
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	err = cmd.Start()
+	require.NoError(t, err, "failed to start the az schema command")
+
+	err = cmd.Wait()
+	t.Log(output)
+	require.NoError(t, err, "az schema failed")
+}


### PR DESCRIPTION
1. Add a test that checked that the schema was packed into the binary properly. This may not always fail on a dev machine but will consistently fail on CI when we forgot to add `//go:generate packr2` or to run `generate`.
2. Call `generate` before `xbuild-all` which builds the final binaries that we publish.