### PR TITLE
fix(schema.json): add missing suppress-output entry

### DIFF
--- a/pkg/az/schema/schema.json
+++ b/pkg/az/schema/schema.json
@@ -90,6 +90,10 @@
         },
         "outputs": {
           "$ref": "#/definitions/outputs"
+        },
+        "suppress-output": {
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
* adds missing `suppress-output` field entry to the mixin schema

Closes https://github.com/deislabs/porter-az/issues/18
Closes https://github.com/deislabs/porter-az/issues/17
Closes https://github.com/deislabs/porter/issues/1262